### PR TITLE
First pass at lma smoothing filter

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -338,3 +338,24 @@ FAST_CODE float fastKalmanUpdate(fastKalman_t *filter, float input)
     filter->x += filter->k * (input - filter->x);
     return filter->x;
 }
+
+void lmaSmoothingInit(laggedMovingAverage_t *filter, uint8_t windowSize, float weight)
+{
+    filter->movingWindowIndex = 0;
+    filter->windowSize = windowSize;
+    filter->weight = weight;
+}
+
+float lmaSmoothingUpdate(laggedMovingAverage_t *filter, float input)
+{
+    if (filter->windowSize && filter->weight) {
+        filter->movingSum -= filter->buf[filter->movingWindowIndex];
+        filter->buf[filter->movingWindowIndex] = input;
+        filter->movingSum += input;
+        filter->movingWindowIndex = (filter->movingWindowIndex + 1) % filter->windowSize;
+
+        return input + (((filter->movingSum  / (float)filter->windowSize) - input) * filter->weight);
+    } else {
+        return input;
+    }
+}

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -25,6 +25,8 @@
 #define MAX_FIR_DENOISE_WINDOW_SIZE 120
 #endif
 
+#define MAX_LMA_WINDOW_SIZE 12
+
 struct filter_s;
 typedef struct filter_s filter_t;
 
@@ -58,6 +60,14 @@ typedef struct fastKalman_s {
     float x;       // state
     float lastX;   // previous state
 } fastKalman_t;
+
+typedef struct laggedMovingAverage_s {
+    int movingWindowIndex;
+    int windowSize;
+    float weight;
+    float movingSum;
+    float buf[MAX_LMA_WINDOW_SIZE];
+} laggedMovingAverage_t;
 
 typedef enum {
     FILTER_PT1 = 0,
@@ -99,6 +109,9 @@ void biquadRCFIR2FilterInit(biquadFilter_t *filter, uint16_t f_cut, float dT);
 
 void fastKalmanInit(fastKalman_t *filter, uint16_t f_cut, float dT);
 float fastKalmanUpdate(fastKalman_t *filter, float input);
+
+void lmaSmoothingInit(laggedMovingAverage_t *filter, uint8_t windowSize, float weight);
+float lmaSmoothingUpdate(laggedMovingAverage_t *filter, float input);
 
 // not exactly correct, but very very close and much much faster
 #define filterGetNotchQApprox(centerFreq, cutoff)   ((float)(cutoff * centerFreq) / ((float)(centerFreq - cutoff) * (float)(centerFreq + cutoff)))

--- a/src/main/interface/settings.c
+++ b/src/main/interface/settings.c
@@ -368,6 +368,9 @@ const clivalue_t valueTable[] = {
     { "gyro_notch2_hz",             VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_soft_notch_hz_2) },
     { "gyro_notch2_cutoff",         VAR_UINT16 | MASTER_VALUE, .config.minmax = { 0, 16000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_soft_notch_cutoff_2) },
 
+    { "gyro_lma_depth",             VAR_UINT8 | MASTER_VALUE, .config.minmax = {0, 11}, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_lma_depth)},
+    { "gyro_lma_weight",            VAR_UINT8 | MASTER_VALUE, .config.minmax = {0, 100}, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_lma_weight)},
+
     { "moron_threshold",            VAR_UINT8  | MASTER_VALUE, .config.minmax = { 0,  200 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyroMovementCalibrationThreshold) },
     { "gyro_offset_yaw",            VAR_INT16 | MASTER_VALUE, .config.minmax = { -1000, 1000 }, PG_GYRO_CONFIG, offsetof(gyroConfig_t, gyro_offset_yaw) },
 #ifdef USE_GYRO_OVERFLOW_CHECK

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -73,6 +73,9 @@ typedef struct gyroConfig_s {
     uint8_t  gyro_stage1_soft_lpf_type;
     uint16_t gyro_stage1_soft_lpf_hz;
 
+    uint8_t gyro_lma_depth;
+    uint8_t gyro_lma_weight;
+
     uint16_t gyro_soft_notch_hz_1;
     uint16_t gyro_soft_notch_cutoff_1;
     uint16_t gyro_soft_notch_hz_2;


### PR DESCRIPTION
First pass at lagged moving average filter.

**gyro_lma_depth <0-11>** 
Sets number of lagged samples to use in the average.  Does not include current sample, thus gyro_lma_depth 2 would be a three sample average (two lagged samples and current sample).  Indexed from 0 to prevent averaging of one sample and to provide a value that disables the filter (0).

**gyro_lma_weight <0-100>**
Sets weight percentage of average to be applied to current sample.  0 = current sample, 100 = lagged average, 50 = 50% of the difference between the average and the current sample applied to the current sample. Supplying a zero value will disable the filter.